### PR TITLE
Fail in the face of parse errors

### DIFF
--- a/R/modify.R
+++ b/R/modify.R
@@ -22,9 +22,14 @@
 json_modify_text <- function(text, json_path, value, spaces = 4) {
   stopifnot(is.character(text))
   text <- paste(text, collapse = '\n')
-  if (is.null(value)) value <- V8::JS('undefined')
+  if (is.null(value)) {
+    value <- V8::JS('undefined')
+  }
   opts <- if (length(spaces)) {
     list(formattingOptions = list(insertSpaces = spaces > 0, tabSize = spaces))
+  }
+  if (!is.null(json_parse_errors(text))) {
+    stop("Can't modify when there are existing parse errors.")
   }
   jsonc$call('json_modify', text, as.list(json_path), value, opts)
 }
@@ -33,12 +38,12 @@ json_modify_text <- function(text, json_path, value, spaces = 4) {
 #' @rdname jsonedit
 #' @param file path to file on disk. Will be created if it does not exist.
 json_modify_file <- function(file, json_path, value, spaces = 4) {
-  json <- if (file.exists(file)) {
+  text <- if (file.exists(file)) {
     rawToChar(readBin(file, raw(), file.info(file)$size))
   } else {
     "{}"
   }
-  out <- json_modify_text(json, json_path, value, spaces)
+  out <- json_modify_text(text, json_path, value, spaces)
   writeLines(out, file)
 }
 
@@ -46,18 +51,31 @@ json_modify_file <- function(file, json_path, value, spaces = 4) {
 #' @rdname jsonedit
 #' @param spaces number of spaces to indent. Use 0 for tabs.
 json_format_text <- function(text, spaces = 4) {
-  stopifnot(is.character(json))
-  json <- paste(json, collapse = '\n')
+  stopifnot(is.character(text))
+  text <- paste(text, collapse = '\n')
   opts <- list(insertSpaces = spaces > 0, tabSize = spaces)
-  jsonc$call('json_format', json, opts)
+  if (!is.null(json_parse_errors(text))) {
+    stop("Can't format when there are existing parse errors.")
+  }
+  jsonc$call('json_format', text, opts)
 }
 
 #' @export
 #' @rdname jsonedit
 json_format_file <- function(file, spaces = 4) {
-  json <- rawToChar(readBin(file, raw(), file.info(file)$size))
-  out <- json_format_text(json, spaces)
+  text <- rawToChar(readBin(file, raw(), file.info(file)$size))
+  out <- json_format_text(text, spaces)
   writeLines(out, file)
+}
+
+json_parse_errors <- function(text) {
+  stopifnot(is.character(text), length(text) == 1L)
+  out <- jsonc$call("json_parse_errors", text)
+  if (identical(out, list())) {
+    # No errors
+    out <- NULL
+  }
+  out
 }
 
 #' @importFrom V8 v8 JS

--- a/inst/js/bindings.js
+++ b/inst/js/bindings.js
@@ -7,3 +7,9 @@ function json_format(json, opts){
   var edit_result = jsonc.format(json, undefined, opts);
   return jsonc.applyEdits(json, edit_result);
 }
+
+function json_parse_errors(json){
+  const errors = [];
+  jsonc.parseTree(json, errors);
+  return errors;
+}


### PR DESCRIPTION
I feel like if we were to use this then we'd fail early if there are parse errors to avoid weirdness

We get a data frame of info back when there are parse errors which we could use to inform the user about where the problem is

```r
> json_parse_errors('{"a": asdf}')
  error offset length
1     1      6      4
2     4     10      1
> # error 1 = invalid symbol
> # error 4 = value expected
```

For now I'm not using this

https://github.com/microsoft/node-jsonc-parser/blob/fe330190baba3ba630934d27ea2083638feddadc/src/main.ts#L151

Also worth noting that just yesterday they added `startLine` and `startCharacter` to the error output struct, so we'd get that too and it might be easier to show the user info using that info
https://github.com/microsoft/node-jsonc-parser/pull/102